### PR TITLE
Update the public delegate APIs to match `turbo-android`

### DIFF
--- a/strada/src/main/kotlin/dev/hotwire/strada/BridgeDelegate.kt
+++ b/strada/src/main/kotlin/dev/hotwire/strada/BridgeDelegate.kt
@@ -23,11 +23,11 @@ class BridgeDelegate<D : BridgeDestination>(
         observeLifeCycle()
     }
 
-    fun loadBridgeInWebView() {
+    fun onColdBootPageCompleted() {
         bridge?.load()
     }
 
-    fun resetBridge() {
+    fun onColdBootPageStarted() {
         bridge?.reset()
     }
 
@@ -38,7 +38,7 @@ class BridgeDelegate<D : BridgeDestination>(
 
         if (bridge != null) {
             if (shouldReloadBridge()) {
-                loadBridgeInWebView()
+                bridge?.load()
             }
         } else {
             logEvent("bridgeNotInitializedForWebView", destination.bridgeDestinationLocation())

--- a/strada/src/test/kotlin/dev/hotwire/strada/BridgeDelegateTest.kt
+++ b/strada/src/test/kotlin/dev/hotwire/strada/BridgeDelegateTest.kt
@@ -35,14 +35,14 @@ class BridgeDelegateTest {
     }
 
     @Test
-    fun loadBridgeInWebView() {
-        delegate.loadBridgeInWebView()
+    fun onColdBootPageCompleted() {
+        delegate.onColdBootPageCompleted()
         verify(bridge).load()
     }
 
     @Test
-    fun resetBridge() {
-        delegate.resetBridge()
+    fun onColdBootPageStarted() {
+        delegate.onColdBootPageStarted()
         verify(bridge).reset()
     }
 


### PR DESCRIPTION
This updates the public `BridgeDelegate` APIs to match the callback names used in `turbo-android` `TurboWebFragmentCallback`. This makes it easy to setup the `delegate` in a `TurboWebFragment`.

It now looks like this:
```kotlin
class WebFragment : TurboWebFragment(), BridgeDestination {
    
    // ...

    override fun bridgeDestinationLocation(): String {
        return location
    }

    override fun bridgeWebViewIsReady(): Boolean {
        return session.isReady
    }

    override fun bridgeDestinationLifecycleOwner(): LifecycleOwner {
        return viewLifecycleOwner
    }
    
    override fun onColdBootPageStarted(location: String) {
        bridgeDelegate.onColdBootPageStarted()
    }

    override fun onColdBootPageCompleted(location: String) {
        bridgeDelegate.onColdBootPageCompleted()
    }

    override fun onWebViewAttached(webView: TurboWebView) {
        bridgeDelegate.onWebViewAttached(webView)
    }

    override fun onWebViewDetached(webView: TurboWebView) {
        bridgeDelegate.onWebViewDetached()
    }
}
```