### PR TITLE
Bump kotlinx.serialization to 1.5.0 to fix Proguard issues

### DIFF
--- a/strada/build.gradle
+++ b/strada/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1'
+    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0'
     implementation 'androidx.lifecycle:lifecycle-common:2.6.1'
 
     testImplementation 'junit:junit:4.13.2'


### PR DESCRIPTION
As of[ v1.5.0](https://github.com/Kotlin/kotlinx.serialization/releases/tag/v1.5.0-RC), `kotlinx.serialization` now bundles its own Proguard rules. This prevents `@Serializable` and `@SerialName` annotations from getting stripped in release builds.