### PR TITLE
Fix `BridgeDelegate` lifecycle issues

### DIFF
--- a/strada/src/main/kotlin/dev/hotwire/strada/BridgeDelegate.kt
+++ b/strada/src/main/kotlin/dev/hotwire/strada/BridgeDelegate.kt
@@ -19,10 +19,7 @@ class BridgeDelegate<D : BridgeDestination>(
         get() = initializedComponents.map { it.value }
 
     val activeComponents: List<BridgeComponent<D>>
-        get() = when (destinationIsActive) {
-            true -> allComponents
-            else -> emptyList()
-        }
+        get() = allComponents.takeIf { destinationIsActive } ?: emptyList()
 
     init {
         observeLifeCycle()


### PR DESCRIPTION
This addresses three lifecycle bugs that were overlooked:
- When the destination's `onStop()` was called, the `onStop()` event was not passed to the destination's components, because the `destinationIsActive` flag was set to `false` *before* attempting to pass along the `onStop()` event to active components
- The `destinationIsActive` flag defaulted to `true` instead of inspecting the destination's state directly
- Bridge messages received in `bridgeDidReceiveMessage()` did not check to see if the destination was active before passing along the message to the corresponding component. This meant that if a `message` was received from the web after the view had been destroyed, it would lead to a crash in the component if it attempted to access its view.