### PR TITLE
DestinationIsActive should return false when LifecycleOwner is null

### DIFF
--- a/strada/src/main/kotlin/dev/hotwire/strada/BridgeDelegate.kt
+++ b/strada/src/main/kotlin/dev/hotwire/strada/BridgeDelegate.kt
@@ -12,8 +12,10 @@ class BridgeDelegate<D : BridgeDestination>(
 ) {
     internal var bridge: Bridge? = null
     private val initializedComponents = hashMapOf<String, BridgeComponent<D>>()
-    private val lifecycle get() = destination.bridgeDestinationLifecycleOwner().lifecycle
-    private val destinationIsActive get() = lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+    private val lifecycle
+        get() = destination.bridgeDestinationLifecycleOwner()?.lifecycle
+    private val destinationIsActive
+        get() = lifecycle?.currentState?.isAtLeast(Lifecycle.State.STARTED) ?: false
 
     private val allComponents: List<BridgeComponent<D>>
         get() = initializedComponents.map { it.value }
@@ -74,10 +76,15 @@ class BridgeDelegate<D : BridgeDestination>(
     // Lifecycle events
 
     private fun observeLifeCycle() {
-        destination.bridgeDestinationLifecycleOwner().lifecycle.addObserver(object :
+        destination.bridgeDestinationLifecycleOwner()?.lifecycle?.addObserver(object :
             DefaultLifecycleObserver {
-            override fun onStart(owner: LifecycleOwner) { onStart() }
-            override fun onStop(owner: LifecycleOwner) { onStop() }
+            override fun onStart(owner: LifecycleOwner) {
+                onStart()
+            }
+
+            override fun onStop(owner: LifecycleOwner) {
+                onStop()
+            }
         })
     }
 

--- a/strada/src/main/kotlin/dev/hotwire/strada/BridgeDestination.kt
+++ b/strada/src/main/kotlin/dev/hotwire/strada/BridgeDestination.kt
@@ -3,7 +3,11 @@ package dev.hotwire.strada
 import androidx.lifecycle.LifecycleOwner
 
 interface BridgeDestination {
+    /**
+     * If the BridgeDestination LifecycleOwner is a Fragment's ViewLifecycleOwner, make sure to
+     * return null here when the Fragment.getView() == null.
+     */
+    fun bridgeDestinationLifecycleOwner(): LifecycleOwner?
     fun bridgeDestinationLocation(): String
-    fun bridgeDestinationLifecycleOwner(): LifecycleOwner
     fun bridgeWebViewIsReady(): Boolean
 }


### PR DESCRIPTION
When Fragment's View is null, the (View)LifecycleOwner returned in `bridgeDestinationLifecycleOwner` throws an `IllegalStateException`. 
I attempted to fix the problem by allowing to return a nullable `LifecycleOwner` and the consumer of the API should check for `fragment.getView() == null` and return `null` in such case.

This effectively allows us to return `false` when checking the value of `destinationIsActive` outside of the Fragment's view lifecycle.