### PR TITLE
Add a way for apps to obtain a user-agent substring for registered components in the app

### DIFF
--- a/strada/src/main/kotlin/dev/hotwire/strada/Bridge.kt
+++ b/strada/src/main/kotlin/dev/hotwire/strada/Bridge.kt
@@ -125,6 +125,11 @@ class Bridge internal constructor(webView: WebView) {
             }
         }
 
+        fun userAgentSubstring(componentFactories: List<BridgeComponentFactory<*,*>>): String {
+            val components = componentFactories.joinToString(" ") { it.name }
+            return "bridge-components: [$components]"
+        }
+
         @VisibleForTesting
         internal fun initialize(bridge: Bridge) {
             instances.add(bridge)

--- a/strada/src/test/kotlin/dev/hotwire/strada/BridgeTest.kt
+++ b/strada/src/test/kotlin/dev/hotwire/strada/BridgeTest.kt
@@ -134,7 +134,37 @@ class BridgeTest {
         assertEquals(bridge.sanitizeFunctionName("send()"), "send")
     }
 
+    @Test
+    fun userAgentSubstring() {
+        val factories = listOf(
+            BridgeComponentFactory("one", ::OneBridgeComponent),
+            BridgeComponentFactory("two", ::TwoBridgeComponent)
+        )
+
+        val userAgentSubstring = Bridge.userAgentSubstring(factories)
+        assertEquals(userAgentSubstring, "bridge-components: [one two]")
+    }
+
     class AppBridgeDestination : BridgeDestination {
         override fun bridgeWebViewIsReady() = true
+    }
+
+    private abstract class AppBridgeComponent(
+        name: String,
+        delegate: BridgeDelegate<AppBridgeDestination>
+    ) : BridgeComponent<AppBridgeDestination>(name, delegate)
+
+    private class OneBridgeComponent(
+        name: String,
+        delegate: BridgeDelegate<AppBridgeDestination>
+    ) : AppBridgeComponent(name, delegate) {
+        override fun handle(message: Message) {}
+    }
+
+    private class TwoBridgeComponent(
+        name: String,
+        delegate: BridgeDelegate<AppBridgeDestination>
+    ) : AppBridgeComponent(name, delegate) {
+        override fun handle(message: Message) {}
     }
 }


### PR DESCRIPTION
This adds a built-in way for the library to produce a user-agent substring that apps can include in their WebView user-agent and API requests. 

Apps can obtain the user-agent string by calling:
```kotlin
Bridge.userAgentSubstring(componentFactories)
```

It will produce a string that looks like:
```
"bridge-components: [one two three four]"
```

Apps can then include this substring in the user-agent for their `WebView` instances and API requests