### PR TITLE
Move userAgent substring generation from Bridge to Strada namespace

### DIFF
--- a/strada/src/main/kotlin/dev/hotwire/strada/Bridge.kt
+++ b/strada/src/main/kotlin/dev/hotwire/strada/Bridge.kt
@@ -125,11 +125,6 @@ class Bridge internal constructor(webView: WebView) {
             }
         }
 
-        fun userAgentSubstring(componentFactories: List<BridgeComponentFactory<*,*>>): String {
-            val components = componentFactories.joinToString(" ") { it.name }
-            return "bridge-components: [$components]"
-        }
-
         @VisibleForTesting
         internal fun initialize(bridge: Bridge) {
             instances.add(bridge)

--- a/strada/src/main/kotlin/dev/hotwire/strada/Strada.kt
+++ b/strada/src/main/kotlin/dev/hotwire/strada/Strada.kt
@@ -2,4 +2,9 @@ package dev.hotwire.strada
 
 object Strada {
     val config: StradaConfig = StradaConfig()
+
+    fun userAgentSubstring(componentFactories: List<BridgeComponentFactory<*,*>>): String {
+        val components = componentFactories.joinToString(" ") { it.name }
+        return "bridge-components: [$components]"
+    }
 }

--- a/strada/src/test/kotlin/dev/hotwire/strada/BridgeTest.kt
+++ b/strada/src/test/kotlin/dev/hotwire/strada/BridgeTest.kt
@@ -133,15 +133,4 @@ class BridgeTest {
     fun sanitizeFunctionName() {
         assertEquals(bridge.sanitizeFunctionName("replyWith()"), "replyWith")
     }
-
-    @Test
-    fun userAgentSubstring() {
-        val factories = listOf(
-            BridgeComponentFactory("one", TestData::OneBridgeComponent),
-            BridgeComponentFactory("two", TestData::TwoBridgeComponent)
-        )
-
-        val userAgentSubstring = Bridge.userAgentSubstring(factories)
-        assertEquals(userAgentSubstring, "bridge-components: [one two]")
-    }
 }

--- a/strada/src/test/kotlin/dev/hotwire/strada/UserAgentTest.kt
+++ b/strada/src/test/kotlin/dev/hotwire/strada/UserAgentTest.kt
@@ -1,0 +1,17 @@
+package dev.hotwire.strada
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UserAgentTest {
+    @Test
+    fun userAgentSubstring() {
+        val factories = listOf(
+            BridgeComponentFactory("one", TestData::OneBridgeComponent),
+            BridgeComponentFactory("two", TestData::TwoBridgeComponent)
+        )
+
+        val userAgentSubstring = Strada.userAgentSubstring(factories)
+        assertEquals(userAgentSubstring, "bridge-components: [one two]")
+    }
+}


### PR DESCRIPTION
This PR moves user agent substring generation from `Bridge` to the top level `Strada` namespace.

Apps can obtain the user-agent string by calling:
```kotlin
Strada.userAgentSubstring(componentFactories)
```

It will produce a string that looks like:
```
"bridge-components: [one two three four]"
```