### PR TITLE
Move the `debugLoggingEnabled` flag to the Strada.config namespace

### DIFF
--- a/strada/src/main/kotlin/dev/hotwire/strada/StradaConfig.kt
+++ b/strada/src/main/kotlin/dev/hotwire/strada/StradaConfig.kt
@@ -1,5 +1,17 @@
 package dev.hotwire.strada
 
 class StradaConfig internal constructor() {
+    /**
+     * Set a custom JSON converter to easily decode Message.dataJson to a data
+     * object in received messages and to encode a data object back to json to
+     * reply with a custom message back to the web.
+     */
     var jsonConverter: StradaJsonConverter? = null
+
+    /**
+     * Enable debug logging to see message communication from/to the WebView.
+     *
+     * NOTE: You should not enable debug logging in production builds.
+     */
+    var debugLoggingEnabled = false
 }

--- a/strada/src/main/kotlin/dev/hotwire/strada/StradaLog.kt
+++ b/strada/src/main/kotlin/dev/hotwire/strada/StradaLog.kt
@@ -3,13 +3,8 @@ package dev.hotwire.strada
 import android.util.Log
 
 @Suppress("unused")
-object StradaLog {
+internal object StradaLog {
     private const val DEFAULT_TAG = "StradaLog"
-
-    /**
-     * Enable debug logging to see message communication from/to the WebView.
-     */
-    var debugLoggingEnabled = false
 
     internal fun d(msg: String) = log(Log.DEBUG, DEFAULT_TAG, msg)
 
@@ -17,7 +12,7 @@ object StradaLog {
 
     private fun log(logLevel: Int, tag: String, msg: String) {
         when (logLevel) {
-            Log.DEBUG -> if (debugLoggingEnabled) Log.d(tag, msg)
+            Log.DEBUG -> if (Strada.config.debugLoggingEnabled) Log.d(tag, msg)
             Log.ERROR -> Log.e(tag, msg)
         }
     }


### PR DESCRIPTION
This moves the `debugLoggingEnabled` flag to a `Strada.config` option and marks the `StradaLog` as `internal`, since it's no longer necessary to expose to apps.

To enable debug logging an app can call:
```kotlin
Strada.config.debugLoggingEnabled = true
```