### PR TITLE
Enable component testing in apps

### DIFF
--- a/strada/src/main/kotlin/dev/hotwire/strada/BridgeComponent.kt
+++ b/strada/src/main/kotlin/dev/hotwire/strada/BridgeComponent.kt
@@ -20,31 +20,31 @@ abstract class BridgeComponent<in D : BridgeDestination>(
     }
 
     /**
+     * Returns the last received message for a given `event`, if available.
+     */
+    protected fun receivedMessageFor(event: String): Message? {
+        return receivedMessages[event]
+    }
+
+    /**
+     * Called when a message is received from the web bridge. Handle the
+     * message for its `event` type for the custom component's behavior.
+     */
+    abstract fun onReceive(message: Message)
+
+    /**
      * Called when the component's destination starts (and is active)
      * based on its lifecycle events. You can use this as an opportunity
      * to update the component's state/view.
      */
-    protected open fun onStart() {}
+    open fun onStart() {}
 
     /**
      * Called when the component's destination stops (and is inactive)
      * based on its lifecycle events. You can use this as an opportunity
      * to update the component's state/view.
      */
-    protected open fun onStop() {}
-
-    /**
-     * Called when a message is received from the web bridge. Handle the
-     * message for its `event` type for the custom component's behavior.
-     */
-    protected abstract fun onReceive(message: Message)
-
-    /**
-     * Returns the last received message for a given `event`, if available.
-     */
-    protected fun receivedMessageFor(event: String): Message? {
-        return receivedMessages[event]
-    }
+    open fun onStop() {}
 
     /**
      * Reply to the web with a received message, optionally replacing its
@@ -99,11 +99,6 @@ abstract class BridgeComponent<in D : BridgeDestination>(
     }
 
     private fun reply(message: Message): Boolean {
-        delegate.bridge?.replyWith(message) ?: run {
-            logEvent("bridgeMessageFailedToReply", "bridge is not available")
-            return false
-        }
-
-        return true
+        return delegate.replyWith(message)
     }
 }

--- a/strada/src/main/kotlin/dev/hotwire/strada/BridgeDelegate.kt
+++ b/strada/src/main/kotlin/dev/hotwire/strada/BridgeDelegate.kt
@@ -44,6 +44,15 @@ class BridgeDelegate<D : BridgeDestination>(
         bridge = null
     }
 
+    fun replyWith(message: Message): Boolean {
+        bridge?.replyWith(message) ?: run {
+            logEvent("bridgeMessageFailedToReply", "bridge is not available")
+            return false
+        }
+
+        return true
+    }
+
     internal fun bridgeDidInitialize() {
         bridge?.register(componentFactories.map { it.name })
     }

--- a/strada/src/main/kotlin/dev/hotwire/strada/Message.kt
+++ b/strada/src/main/kotlin/dev/hotwire/strada/Message.kt
@@ -1,6 +1,6 @@
 package dev.hotwire.strada
 
-data class Message internal constructor(
+data class Message constructor(
     /**
      * A unique identifier for this message. When you reply to the web with
      * a message, this identifier is used to find its previously sent message.

--- a/strada/src/test/kotlin/dev/hotwire/strada/BridgeComponentTest.kt
+++ b/strada/src/test/kotlin/dev/hotwire/strada/BridgeComponentTest.kt
@@ -12,7 +12,6 @@ import org.junit.Test
 class BridgeComponentTest {
     private lateinit var component: TestData.OneBridgeComponent
     private val delegate: BridgeDelegate<TestData.AppBridgeDestination> = mock()
-    private val bridge: Bridge = mock()
 
     private val message = Message(
         id = "1",
@@ -26,7 +25,6 @@ class BridgeComponentTest {
     fun setup() {
         Strada.config.jsonConverter = KotlinXJsonConverter()
         component = TestData.OneBridgeComponent("one", delegate)
-        whenever(delegate.bridge).thenReturn(bridge)
     }
 
     @Test
@@ -70,18 +68,16 @@ class BridgeComponentTest {
         val newJsonData = """{"title":"Page-title"}"""
         val newMessage = message.replacing(jsonData = newJsonData)
 
-        val replied = component.replyWith(newMessage)
-        assertEquals(true, replied)
-        verify(bridge).replyWith(eq(newMessage))
+        component.replyWith(newMessage)
+        verify(delegate).replyWith(eq(newMessage))
     }
 
     @Test
     fun replyTo() {
         component.didReceive(message)
 
-        val replied = component.replyTo("connect")
-        assertEquals(true, replied)
-        verify(bridge).replyWith(eq(message))
+        component.replyTo("connect")
+        verify(delegate).replyWith(eq(message))
     }
 
     @Test
@@ -91,9 +87,8 @@ class BridgeComponentTest {
 
         component.didReceive(message)
 
-        val replied = component.replyTo("connect", newJsonData)
-        assertEquals(true, replied)
-        verify(bridge).replyWith(eq(newMessage))
+        component.replyTo("connect", newJsonData)
+        verify(delegate).replyWith(eq(newMessage))
     }
 
     @Test
@@ -103,9 +98,8 @@ class BridgeComponentTest {
 
         component.didReceive(message)
 
-        val replied = component.replyTo("connect", MessageData(title = "Page-title"))
-        assertEquals(true, replied)
-        verify(bridge).replyWith(eq(newMessage))
+        component.replyTo("connect", MessageData(title = "Page-title"))
+        verify(delegate).replyWith(eq(newMessage))
     }
 
     @Test
@@ -121,18 +115,16 @@ class BridgeComponentTest {
 
     @Test
     fun replyToIgnoresNotReceived() {
-        val replied = component.replyTo("connect")
-        assertEquals(false, replied)
-        verify(bridge, never()).replyWith(any())
+        component.replyTo("connect")
+        verify(delegate, never()).replyWith(any())
     }
 
     @Test
     fun replyToReplacingJsonDataIgnoresNotReceived() {
         val newJsonData = """{"title":"Page-title"}"""
 
-        val replied = component.replyTo("connect", newJsonData)
-        assertEquals(false, replied)
-        verify(bridge, never()).replyWith(any())
+        component.replyTo("connect", newJsonData)
+        verify(delegate, never()).replyWith(any())
     }
 
     @Serializable

--- a/strada/src/test/kotlin/dev/hotwire/strada/BridgeDelegateTest.kt
+++ b/strada/src/test/kotlin/dev/hotwire/strada/BridgeDelegateTest.kt
@@ -91,6 +91,33 @@ class BridgeDelegateTest {
     }
 
     @Test
+    fun replyWith() {
+        val message = Message(
+            id = "1",
+            component = "page",
+            event = "connect",
+            metadata = Metadata("https://37signals.com/another_url"),
+            jsonData = """{"title":"Page-title","subtitle":"Page-subtitle"}"""
+        )
+
+        assertEquals(true, delegate.replyWith(message))
+    }
+
+    @Test
+    fun replyWithFailsWithoutBridge() {
+        val message = Message(
+            id = "1",
+            component = "page",
+            event = "connect",
+            metadata = Metadata("https://37signals.com/another_url"),
+            jsonData = """{"title":"Page-title","subtitle":"Page-subtitle"}"""
+        )
+
+        delegate.bridge = null
+        assertEquals(false, delegate.replyWith(message))
+    }
+
+    @Test
     fun onWebViewAttached() {
         whenever(bridge.isReady()).thenReturn(false)
         delegate.onWebViewAttached(webView)


### PR DESCRIPTION
This avoids accessing the `bridge` directly from within the `BridgeComponent` class to enable component testing in apps by mocking the component's `delegate`. Apps can test tests messages that are called through `BridgeDelegate.replyWith(message)`.