### PR TITLE
Fix URL Comparison Issue in bridgeDidReceiveMessage Function

### DIFF
--- a/strada/src/main/kotlin/dev/hotwire/strada/BridgeDelegate.kt
+++ b/strada/src/main/kotlin/dev/hotwire/strada/BridgeDelegate.kt
@@ -58,7 +58,10 @@ class BridgeDelegate<D : BridgeDestination>(
     }
 
     internal fun bridgeDidReceiveMessage(message: Message): Boolean {
-        return if (destinationIsActive && location == message.metadata?.url) {
+        val sanitizedLocation = location.trimEnd('/')
+        val sanitizedUrl = message.metadata?.url?.trimEnd('/')
+
+        return if (destinationIsActive && sanitizedLocation == sanitizedUrl) {
             logEvent("bridgeDidReceiveMessage", message.toString())
             getOrCreateComponent(message.component)?.didReceive(message)
             true


### PR DESCRIPTION
### Problem:
In the `bridgeDidReceiveMessage` function, there was an inconsistency in URL comparison. When one of the URLs had a trailing slash and the other didn't, the comparison would fail.

### Solution:
Updated the logic to trim any trailing slashes from both `location` and `message.metadata?.url` before comparing them. This ensures that the comparison is consistent, irrespective of the presence of a trailing slash in either URL.

### Notes:
This fix improves the reliability of the message processing logic and ensures that messages are correctly received or ignored based on their metadata URLs.
