### PR TITLE
Upgrade AGP, SDK version, Kotlin version and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Requirements
 
-1. Android SDK 24+ is required as the `minSdkVersion` in your build.gradle.
+1. Android SDK 26+ is required as the `minSdkVersion` in your build.gradle.
 1. This library is written entirely in [Kotlin](https://kotlinlang.org/), and your app should use Kotlin as well. Compatibility with Java is not provided or supported.
 1. This library supports [Turbo Native](https://turbo.hotwired.dev/handbook/native) hybrid apps.
 1. Your web app must be running [strada-web](https://github.com/hotwired/strada-web). The `window.Strada` object is automatically exposed on the loaded WebView page, which enables `strada-android` to work.

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlinVersion = '1.7.20'
+    ext.kotlinVersion = '1.9.10'
 
     repositories {
         google()
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.0'
+        classpath 'com.android.tools.build:gradle:8.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -16,10 +16,10 @@ See the [latest version](https://search.maven.org/artifact/dev.hotwire/strada) a
 **Note:** `strada-android` works seamlessly with [turbo-android](https://github.com/hotwired/turbo-android) and the documentation provides instructions for integrating Strada with your [Turbo Native](https://turbo.hotwired.dev/handbook/native) app. Keep in mind that `turbo-android` is not automatically included as a dependency in `strada-android`, so you'll want to setup your `turbo-android` app first.
 
 ## Required `minSdkVersion`
-Android SDK 24 (or greater) is required as the `minSdkVersion` in your app module's `build.gradle` file:
+Android SDK 26 (or greater) is required as the `minSdkVersion` in your app module's `build.gradle` file:
 ```groovy
 defaultConfig {
-    minSdkVersion 24
+    minSdkVersion 26
     ...
 }
 ```

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
+#Wed Feb 28 14:58:13 EST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/strada/build.gradle
+++ b/strada/build.gradle
@@ -44,7 +44,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdkVersion 24
+        minSdkVersion 26
         targetSdkVersion 34
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/strada/build.gradle
+++ b/strada/build.gradle
@@ -41,11 +41,11 @@ repositories {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdk = 34
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 34
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -87,16 +87,16 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.core:core-ktx:1.12.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0'
-    implementation 'androidx.lifecycle:lifecycle-common:2.6.1'
+    implementation 'androidx.lifecycle:lifecycle-common:2.7.0'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'androidx.test:core:1.5.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'androidx.lifecycle:lifecycle-runtime-testing:2.6.1'
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4"
-    testImplementation 'org.robolectric:robolectric:4.9.2'
+    testImplementation 'androidx.lifecycle:lifecycle-runtime-testing:2.7.0'
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3"
+    testImplementation 'org.robolectric:robolectric:4.11.1'
     testImplementation 'org.mockito:mockito-core:5.2.0'
     testImplementation 'com.nhaarman:mockito-kotlin:1.6.0'
 }


### PR DESCRIPTION
This requires Android Studio Hedgehog. See: https://developer.android.com/build/releases/gradle-plugin

This also bumps the `minSdkVersion` to `26`. Google is ending support for Chrome on Android 7 (and the system WebView), so this change corresponds to Google's decision. https://www.androidpolice.com/chrome-120-ending-support-for-android-nougat/