### PR TITLE
JSON serializer configuration update

### DIFF
--- a/strada/src/main/kotlin/dev/hotwire/strada/JsonExtensions.kt
+++ b/strada/src/main/kotlin/dev/hotwire/strada/JsonExtensions.kt
@@ -1,5 +1,6 @@
 package dev.hotwire.strada
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -27,4 +28,10 @@ internal inline fun <reified T> String.decode(): T? = try {
     null
 }
 
-private val json = Json { ignoreUnknownKeys = true }
+@OptIn(ExperimentalSerializationApi::class)
+private val json = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = true
+    explicitNulls = false
+    isLenient = true
+}

--- a/strada/src/main/kotlin/dev/hotwire/strada/StradaJsonConverter.kt
+++ b/strada/src/main/kotlin/dev/hotwire/strada/StradaJsonConverter.kt
@@ -1,9 +1,9 @@
 package dev.hotwire.strada
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import java.lang.Exception
 
 abstract class StradaJsonConverter {
     companion object {
@@ -42,12 +42,18 @@ abstract class StradaJsonTypeConverter : StradaJsonConverter() {
 }
 
 class KotlinXJsonConverter : StradaJsonConverter() {
-    val json = Json { ignoreUnknownKeys = true }
+    @OptIn(ExperimentalSerializationApi::class)
+    val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+        explicitNulls = false
+        isLenient = true
+    }
 
     inline fun <reified T> toObject(jsonData: String): T? {
         return try {
             json.decodeFromString(jsonData)
-        } catch(e: Exception) {
+        } catch (e: Exception) {
             logException(e)
             null
         }


### PR DESCRIPTION
This PR updates JSON serialization configuration to encode properties with default values (previously, it skipped them, potentially causing problems with bridge messages) and makes the serializer generally more lenient.